### PR TITLE
Changing resize function parameters from integer to float to fix PHP deprecation

### DIFF
--- a/inc/wp-components/classes/class-image.php
+++ b/inc/wp-components/classes/class-image.php
@@ -715,16 +715,16 @@ class Image extends Component {
 	}
 
 	/**
-	 * Resize and crop an image to exact width, height pixel dimensions. Set the
+	 * Resize and crop an image to exact width,height pixel dimensions. Set the
 	 * first number as close to the target size as possible and then crop the
-	 * rest. Which direction it's resized and cropped depends on the aspect
+	 * rest. Which direction it’s resized and cropped depends on the aspect
 	 * ratios of the original image and the target size.
 	 *
 	 * @see  https://developer.wordpress.com/docs/photon/api/#resize
 	 *
 	 * @param float $width  Resized width.
 	 * @param float $height Resized height.
-	 * @param int   $density_multiplier screen density multiplier.
+	 * @param int $density_multiplier screen density multiplier.
 	 * @return array Transform values prepared to be added as query args.
 	 */
 	public function resize( float $width, float $height, $density_multiplier = 1 ) {

--- a/inc/wp-components/classes/class-image.php
+++ b/inc/wp-components/classes/class-image.php
@@ -715,19 +715,19 @@ class Image extends Component {
 	}
 
 	/**
-	 * Resize and crop an image to exact width,height pixel dimensions. Set the
+	 * Resize and crop an image to exact width, height pixel dimensions. Set the
 	 * first number as close to the target size as possible and then crop the
-	 * rest. Which direction it’s resized and cropped depends on the aspect
+	 * rest. Which direction it's resized and cropped depends on the aspect
 	 * ratios of the original image and the target size.
 	 *
 	 * @see  https://developer.wordpress.com/docs/photon/api/#resize
 	 *
-	 * @param int $width  Resized width.
-	 * @param int $height Resized height.
-	 * @param int $density_multiplier screen density multiplier.
+	 * @param float $width  Resized width.
+	 * @param float $height Resized height.
+	 * @param int   $density_multiplier screen density multiplier.
 	 * @return array Transform values prepared to be added as query args.
 	 */
-	public function resize( int $width, int $height, $density_multiplier = 1 ) {
+	public function resize( float $width, float $height, $density_multiplier = 1 ) {
 		$value = sprintf(
 			'%1$d,%2$d',
 			absint( $width ) * $density_multiplier,


### PR DESCRIPTION
This pull request changes the `resize` function `params` from `integer` to `float` to fix PHP deprecations.

For additional context, please refer to [TECH-435](https://technologyreview.atlassian.net/browse/TECH-435).