### PR TITLE
avoid dynamic property creation warning

### DIFF
--- a/inc/wp-components/classes/class-component.php
+++ b/inc/wp-components/classes/class-component.php
@@ -31,7 +31,9 @@ class Component implements \JsonSerializable {
 	 *
 	 * @var array
 	 */
-	public $children = [];
+	public $children = [
+		'theme_name' => '',
+	];
 
 	/**
 	 * Component groups.


### PR DESCRIPTION
This pull request changes the `Component` class' `$children` to include a `theme_name` property by default. This prevents a PHP warning from happening when code that uses this class tries to set the value of the `theme_name` property on the `$children` variable.

The warning that caused this change:

```
PHP message: Deprecated: Creation of dynamic property MITTR\Components\Content\Sponsored_Module::$theme_name is deprecated in /var/www/wp-content/themes/mittr/data/class-custom-content.php on line 128 [wp-develop.technologyreview.com/wp-json/irving/v1/data/custom_content?page=1&orderBy=date] [wp-content/themes/mittr/data/class-custom-content.php:87 MITTR\Data\Custom_Content->generate_story_cards(), wp-includes/rest-api/class-wp-rest-server.php:1230 MITTR\Data\Custom_Content->get_data(), wp-includes/rest-api/class-wp-rest-server.php:1063 WP_REST_Server->respond_to_request(), wp-includes/rest-api/class-wp-rest-server.php:439 WP_REST_Server->dispatch(), wp-includes/rest-api.php:428 WP_REST_Server->serve_request(), wp-includes/class-wp-hook.php:324 rest_api_loaded(), wp-includes/class-wp-hook.php:348 WP_Hook->apply_filters(), wp-includes/plugin.php:565 WP_Hook->do_action(), wp-includes/class-wp.php:418 do_action_ref_array(), wp-includes/class-wp.php:813 WP->parse_request(), wp-includes/functions.php:1336 WP->main(), wp-blog-header.php:16 wp(), index.php:17 require('wp-blog-header.php')]
```

For additional context, please refer to [TECH-568](https://technologyreview.atlassian.net/browse/TECH-568).